### PR TITLE
Rename KafkaProxyIngress to KafkaGateway

### DIFF
--- a/proposals/kroxylicious-operator-api-alternative.md
+++ b/proposals/kroxylicious-operator-api-alternative.md
@@ -119,8 +119,8 @@ metadata:
 spec:
   # reference to the proxy that will use this gateway.
   proxyRef:
-    kind: KafkaProxy  # if present must be Gateway, otherwise defaulted
-    group: kroxylicious.io # if present must be proxy.kroxylicious, otherwise defaulted=
+    kind: KafkaProxy  # if present must be KafkaProxy, otherwise defaulted
+    group: kroxylicious.io # if present must be kroxylicious.io, otherwise defaulted=
     name: myproxy  # name of proxy
 
   # oneOf: clusterIP, loadBalancer, openShiftRoute, gateway


### PR DESCRIPTION
We have landed on [Gateway](https://github.com/kroxylicious/kroxylicious/pull/1848#issuecomment-2690076942) as our grudgingly preferred name for "the thing that presents one (or more) virtual kafka cluster to the network".

The Kafka protocol requires us to be able to identify each node that the client is attempting to connect to, so that we can forward the traffic to the correct upstream broker. Our strategies are to map the listening port, or the SNI hostname, to the upstream node id. Because one of theses strategies spans numerous ports, we found it awkward to name it a `listener` or `ingress`.

Gateway is similarly overloaded, but we think it's a better term for this melange of "how do we expose this cluster to the world", and "how do we map connections to nodes".