### PR TITLE
plugin api to select tls credentials for server connection

### DIFF
--- a/proposals/011-plugin-api-to-select-tls-credentials-for-server-connection.md
+++ b/proposals/011-plugin-api-to-select-tls-credentials-for-server-connection.md
@@ -1,7 +1,7 @@
 # Plugin API for selecting TLS client credentials for proxy-to-server connection
 
 This proposes a new plugin API for allowing the selection of the TLS client credentials to be used for the connection between the proxy and a Kafka server.
-It makes use of [proposal-004](proposal-004) for the terminology used.
+It makes use of [proposal-004](./004-terminology-for-authentication.md) for the terminology used.
 
 ## Current situation
 


### PR DESCRIPTION
It's been suggested to break https://github.com/kroxylicious/design/pull/71 into separate proposals to simplify review etc. This PR adds a proposal for a plugin API for runtime selection of the TLS certificate to be used on the proxy-to-server connection.