### PR TITLE
007 - Add topic name lookup facility

### DIFF
--- a/proposals/007-topic-name-lookup-facility.md
+++ b/proposals/007-topic-name-lookup-facility.md
@@ -1,7 +1,7 @@
 # Proposal 007: Resolve Topic Names from Topic IDs in the Filter Framework
 
 <!-- TOC -->
-* [Proposal 008: Resolve Topic Names from Topic IDs in the Filter Framework](#proposal-008-resolve-topic-names-from-topic-ids-in-the-filter-framework)
+* [Proposal 007: Resolve Topic Names from Topic IDs in the Filter Framework](#proposal-007-resolve-topic-names-from-topic-ids-in-the-filter-framework)
   * [Summary](#summary)
   * [Current Situation](#current-situation)
   * [Motivation](#motivation)


### PR DESCRIPTION
This proposal outlines a new feature for the Kroxylicious filter framework: a mechanism to resolve topic names from their corresponding topic IDs. This will enable filters to implement business logic based on human-readable topic names, rather than the underlying Kafka implementation detail of topic IDs.