### PR TITLE
fix(actions): proposal numbering body update failed

### DIFF
--- a/.github/workflows/proposal-numbering.yml
+++ b/.github/workflows/proposal-numbering.yml
@@ -11,7 +11,7 @@
 name: Check Proposal Numbering
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Check proposal file numbering
         id: check


### PR DESCRIPTION
PRs from forks do not have permissions to write the PR

https://github.com/kroxylicious/design/actions/runs/25076591595

Switching to pull_request_target will enable the write Note that this is safe for the design repo as we don't execute any code from the PR.