### PR TITLE
Propose rack-aware SNI broker address patterns

### DIFF
--- a/proposals/000-rack-aware-sni-broker-address-patterns.md
+++ b/proposals/000-rack-aware-sni-broker-address-patterns.md
@@ -1,0 +1,224 @@
+# 000 - Rack-aware SNI broker address patterns
+
+This proposal adds optional rack-aware broker address generation to the SNI node identification strategy.
+It allows an advertised broker address pattern to include broker rack metadata learned from Kafka metadata responses.
+
+## Current situation
+
+Kroxylicious supports SNI-based node identification through `sniHostIdentifiesNode`.
+In this mode, a virtual cluster has a bootstrap address and an `advertisedBrokerAddressPattern`.
+The pattern is used when Kroxylicious rewrites broker addresses in Kafka protocol responses, and also when it creates broker-specific endpoints that can later be reverse-mapped from SNI hostnames back to Kafka node IDs.
+
+The existing advertised broker address pattern supports tokens such as:
+
+```text
+$(nodeId)
+$(virtualClusterName)
+$(unresolvedRouteHost)
+```
+
+This is enough when broker-specific advertised DNS names only need to vary by Kafka node ID.
+It is not enough when operators need advertised broker names to include topology information such as a rack or availability-zone label.
+
+Kafka brokers can expose rack metadata in metadata responses.
+Kroxylicious currently does not make that value available to the SNI node identification strategy when generating advertised broker addresses.
+
+## Motivation
+
+Some deployments need broker-specific advertised addresses that include a topology label.
+For example, a deployment may require DNS names with both node ID and rack-like placement:
+
+```text
+broker-0-az1.example.net
+broker-1-az2.example.net
+broker-2-az3.example.net
+```
+
+This can be useful when DNS, certificates, routing policy, or operational conventions require addresses to encode placement information.
+The common source of that placement information in Kafka is the broker rack metadata.
+
+One important use case is reducing avoidable cross-zone traffic.
+In a multi-zone deployment, the client-facing load balancer, the Kroxylicious pod handling the connection, and the Kafka broker that leads a partition may all be placed in different zones.
+For example:
+
+```text
+client -> network load balancer endpoint in zone-a
+       -> Kroxylicious pod in zone-b
+       -> Kafka broker or partition leader in zone-c
+```
+
+When traffic crosses zone boundaries between these hops, operators may pay inter-zone data transfer charges and may also see additional latency.
+This is especially relevant for Kafka because produce and fetch traffic can be high-volume.
+If broker-specific advertised hostnames include a rack or zone label, operators can configure DNS, load balancer targets, ingress policy, or deployment topology so that clients prefer a Kroxylicious endpoint in the same zone as the broker rack or failure domain where possible.
+
+Kroxylicious does not need to implement the network placement policy itself.
+It only needs to advertise broker hostnames that contain enough topology information for the surrounding DNS and load-balancing infrastructure to make zone-aware routing decisions.
+This does not guarantee that all traffic is zone-local; rather, it gives operators a stable naming mechanism they can use to reduce avoidable cross-zone hops in their own network design.
+
+This proposal deliberately treats the value as generic Kafka rack metadata, not as a cloud-provider-specific availability zone.
+Different Kafka deployments may use rack values to represent physical racks, cloud availability zones, failure domains, or provider-specific placement identifiers.
+Kroxylicious should not call cloud-provider APIs to interpret those values.
+Instead, it should use the rack value that Kafka already exposes and let operators optionally map raw rack values to DNS-friendly labels.
+
+## Proposal
+
+Extend the SNI node identification strategy so `advertisedBrokerAddressPattern` may use these additional tokens:
+
+```text
+$(rackId)
+$(rackId:<default>)
+```
+
+When Kroxylicious rewrites a metadata response, it uses the broker rack value from the metadata response for `$(rackId)`.
+When a mapping is configured, the raw rack value is first translated through that mapping before being substituted into the advertised hostname.
+
+Example configuration:
+
+```yaml
+sniHostIdentifiesNode:
+  bootstrapAddress: "cluster.example.net:9192"
+  advertisedBrokerAddressPattern: "broker-$(nodeId)-$(rackId:az1).example.net:9192"
+  rackIdMappings:
+    euc1-az1: az1
+    euc1-az2: az2
+    euc1-az3: az3
+```
+
+If broker `0` has rack value `euc1-az1`, Kroxylicious advertises:
+
+```text
+broker-0-az1.example.net:9192
+```
+
+That advertised hostname can then be backed by operator-managed DNS or load-balancer policy.
+For example, `az1` can resolve to proxy endpoints in zone `az1`, while `az2` resolves to proxy endpoints in zone `az2`.
+The exact DNS and networking implementation remains outside Kroxylicious.
+
+If the broker rack value is unavailable and the token has a default, the default is used:
+
+```text
+$(rackId:az1)
+```
+
+If the broker rack value is unavailable and the token has no default, address generation fails.
+This makes misconfiguration visible rather than silently advertising an incomplete or incorrect hostname.
+
+### Rack ID mappings
+
+`rackIdMappings` is an optional map on the SNI node identification strategy.
+Keys are raw Kafka rack values.
+Values are replacement labels used in the advertised broker address.
+
+For example:
+
+```yaml
+rackIdMappings:
+  euc1-az1: az1
+```
+
+This lets operators keep stable DNS labels even when raw Kafka rack values differ between environments or providers.
+It also avoids making Kroxylicious aware of cloud-provider-specific naming rules.
+
+If no mapping exists for a non-empty rack value, the raw rack value is used as-is.
+Operators should configure mappings when raw rack values are not suitable for use in DNS hostnames, or when they want stable DNS labels that differ from the values exposed by Kafka.
+
+### Usage model
+
+This feature is intended to compose with infrastructure that already supports zone-aware routing.
+For example, an operator might:
+
+* configure Kafka broker rack values to represent broker failure domains,
+* configure Kroxylicious pods or services in the same failure domains,
+* advertise broker hostnames containing `$(rackId)` or a mapped rack label,
+* configure DNS or load-balancer policy so each rack label resolves to the appropriate Kroxylicious endpoint.
+
+Kroxylicious remains responsible for producing consistent advertised broker hostnames and reverse-mapping those hostnames back to broker node IDs.
+The surrounding infrastructure remains responsible for resolving and routing those hostnames.
+
+### Metadata response rewriting
+
+When handling Kafka metadata responses, Kroxylicious already rewrites upstream broker host and port values into client-facing broker addresses.
+This proposal extends that path to pass the broker rack value to the node identification strategy when generating the advertised broker address.
+
+The rack value is only available in responses that carry broker rack metadata.
+Other response types that contain broker endpoints continue to use the existing node-ID-only behavior unless rack metadata is available.
+
+### Endpoint registration and reverse mapping
+
+The same rack-aware address generation must be used when registering broker-specific SNI endpoints.
+Otherwise Kroxylicious could advertise one hostname in metadata but bind or route a different hostname internally.
+
+The SNI reverse mapping remains node-ID based.
+When the advertised broker address pattern contains a rack token, reverse mapping treats the rack portion of the hostname as a non-node-ID label and continues to extract the node ID from `$(nodeId)`.
+
+For example, both patterns still resolve node ID correctly:
+
+```text
+broker-$(nodeId)-$(rackId).example.net
+broker-$(rackId).$(nodeId).example.net
+```
+
+### Scope
+
+This proposal is limited to the SNI node identification strategy.
+It does not change the port-based node identification strategy.
+It does not introduce cloud-provider integrations.
+It does not require users to configure rack-aware patterns.
+
+## Affected/not affected projects
+
+Affected:
+
+* `kroxylicious-runtime`, specifically broker address pattern parsing, metadata response rewriting, SNI node identification, and endpoint reconciliation.
+* Runtime tests covering SNI address generation, metadata rewrite behavior, and endpoint registration.
+
+Not affected:
+
+* `portIdentifiesNode` behavior.
+* Existing SNI configurations that only use `$(nodeId)` and existing supported tokens.
+* Kubernetes operator APIs, unless a future proposal chooses to surface validation or documentation through Kubernetes-specific schema changes.
+* Filter plugin APIs.
+* Cloud-provider KMS providers and other unrelated integrations.
+
+## Compatibility
+
+This is a backward-compatible configuration extension.
+Existing configurations remain valid and keep their existing behavior.
+
+The new behavior is opt-in:
+
+* If `advertisedBrokerAddressPattern` does not contain `$(rackId)` or `$(rackId:<default>)`, rack metadata is ignored.
+* Existing tokens retain their current meaning.
+* Strategies that do not use rack metadata continue to generate broker addresses from node ID alone.
+
+There are compatibility considerations for `$(rackId)` without a default.
+If the upstream Kafka cluster does not expose broker rack metadata, a pattern using `$(rackId)` cannot be resolved.
+Operators can avoid that by using `$(rackId:<default>)`.
+
+The reverse SNI mapping must continue to extract exactly the node ID from the advertised broker hostname.
+Rack labels must not become part of the node identity.
+
+## Rejected alternatives
+
+### Cloud-provider-specific lookup
+
+One option was to have Kroxylicious call cloud-provider APIs to discover placement information such as availability zones or subnets.
+This was rejected because it would make a generic Kafka proxy depend on provider-specific APIs, credentials, permissions, rate limits, and failure modes.
+Kafka already exposes broker rack metadata, and operators can decide what that value means in their environment.
+
+### Implementing this as a filter
+
+This was considered but rejected.
+Filters can rewrite protocol responses, but endpoint registration and SNI reverse mapping are owned by the node identification and endpoint reconciliation path.
+If a filter rewrote metadata independently, Kroxylicious could advertise hostnames that the SNI routing layer did not know how to bind or reverse-map.
+
+### Adding rack metadata to `HostPort`
+
+This was rejected because `HostPort` represents only an address.
+Rack metadata is broker topology metadata, not part of a host/port pair.
+Keeping rack metadata separate avoids leaking broker-specific concerns into a generic address type.
+
+### Making rack ID required
+
+Making rack metadata mandatory was rejected because many Kafka clusters either do not configure broker rack values or do not need rack-aware DNS names.
+The feature should be opt-in and compatible with existing deployments.

--- a/proposals/120-rack-aware-sni-broker-address-patterns.md
+++ b/proposals/120-rack-aware-sni-broker-address-patterns.md
@@ -1,4 +1,4 @@
-# 000 - Rack-aware SNI broker address patterns
+# 120 - Rack-aware SNI broker address patterns
 
 This proposal adds optional rack-aware broker address generation to the SNI node identification strategy.
 It allows an advertised broker address pattern to include broker rack metadata learned from Kafka metadata responses.

--- a/proposals/120-rack-aware-sni-broker-address-patterns.md
+++ b/proposals/120-rack-aware-sni-broker-address-patterns.md
@@ -64,7 +64,7 @@ Instead, it should use the rack value that Kafka already exposes.
 
 ## Proposal
 
-Extend the SNI node identification strategy so `advertisedBrokerAddressPattern` may use these additional tokens:
+Extend the SNI node identification strategy so `advertisedBrokerAddressPattern` may use this additional token:
 
 ```text
 $(rackId)
@@ -139,8 +139,7 @@ Provider-specific values such as availability-zone IDs or subnet-derived placeme
 Today the existing node identification strategies perform basic pattern, token, port, and URI-style checks.
 They do not perform full DNS label validation for generated advertised broker hostnames.
 This proposal does not change that validation model.
-If an advertised address fails the existing validation checks, address generation fails.
-Otherwise, Kroxylicious treats hostname suitability as an operator responsibility, as it does for existing advertised broker address patterns.
+Kroxylicious treats hostname suitability as an operator responsibility, as it does for existing advertised broker address patterns.
 Operators should use `rackIdMappings` to translate arbitrary upstream rack values into advertised address labels that are suitable for their DNS, certificate, and load-balancer conventions.
 
 ### Usage model
@@ -182,7 +181,9 @@ For a SNI configuration using `$(rackId)`, eager endpoint creation uses `rackIdD
 Once upstream metadata has been observed, rack-aware endpoints should be updated by metadata-driven endpoint reconciliation.
 
 If a broker rack value changes, Kroxylicious should treat that as a change in the generated advertised broker address during normal endpoint reconciliation.
-The new hostname should be generated from the updated metadata, and stale endpoint bindings generated from the previous rack value should be removed according to the existing reconciliation lifecycle.
+The new hostname should be generated from the updated metadata, and reconciliation must detect this as an endpoint change even though the node ID is unchanged.
+This requires rack-aware reconciliation logic; the current node-ID membership reconciliation is not sufficient on its own.
+This may be implemented by tracking the effective generated broker address, or by treating `(nodeId, effectiveRackLabel)` as the endpoint identity for rack-aware SNI bindings.
 Existing client connections can continue using the connection they already established, but a client that tries to open a new connection using a cached stale hostname may need to refresh metadata and retry.
 
 ### Endpoint registration and reverse mapping
@@ -211,7 +212,8 @@ Embedding rack labels into broker hostnames does not provide the same routing me
 This is a scoping choice rather than a fundamental limitation.
 If future work defines a useful rack-aware lifecycle and routing model for port-based listeners, it can be considered separately.
 It does not introduce cloud-provider integrations.
-It does not require users to configure rack-aware patterns.
+It does not introduce full DNS label validation for generated advertised broker hostnames.
+It does not require existing users to configure rack-aware patterns.
 
 ## Affected/not affected projects
 

--- a/proposals/120-rack-aware-sni-broker-address-patterns.md
+++ b/proposals/120-rack-aware-sni-broker-address-patterns.md
@@ -1,7 +1,7 @@
 # 120 - Rack-aware SNI broker address patterns
 
 This proposal adds rack-derived broker address generation to the SNI node identification strategy.
-It uses broker rack metadata learned from Kafka metadata responses and configured DNS label mappings to build advertised broker addresses without changing Kafka protocol rack metadata.
+It uses broker rack metadata learned from Kafka metadata responses, a required `rackIdDefault`, and optional `rackIdMappings` to build advertised broker addresses without changing Kafka protocol rack metadata.
 
 ## Current situation
 
@@ -42,11 +42,12 @@ In a multi-zone deployment, the client-facing load balancer, the Kroxylicious po
 For example:
 
 ```text
-Client → Network Load Balancer (NLB) endpoint in Zone A
-*(assuming cross-zone load balancing is disabled between the NLB and Kroxylicious pods)*
-→ Kroxylicious pod in Zone A
-→ Kafka broker or partition leader in Zone C
+client -> Network Load Balancer (NLB) endpoint in Zone A
+       -> Kroxylicious pod in Zone A
+       -> Kafka broker or partition leader in Zone C
 ```
+
+This example assumes cross-zone load balancing is disabled between the NLB and Kroxylicious pods.
 When traffic crosses zone boundaries between these hops, operators may pay inter-zone data transfer charges and may also see additional latency.
 This is especially relevant for Kafka because produce and fetch traffic can be high-volume.
 If broker-specific advertised hostnames include a rack or zone label, operators can configure DNS, load balancer targets, ingress policy, or deployment topology so that clients prefer a Kroxylicious endpoint in the same zone as the broker rack or failure domain where possible.
@@ -70,8 +71,8 @@ $(rackId)
 ```
 
 When Kroxylicious rewrites a metadata response, it uses the broker rack value from the metadata response for `$(rackId)`.
-If `rackIdMappings` is configured, Kroxylicious first translates the upstream rack value into an advertised address label.
-If the upstream rack value is missing or does not have a mapping, Kroxylicious uses `rackIdDefault` if configured.
+If `rackIdMappings` contains the upstream rack value, Kroxylicious translates it into the configured advertised address label.
+If the upstream rack value is missing or does not have a mapping, Kroxylicious uses `rackIdDefault`.
 
 Example configuration:
 
@@ -96,8 +97,8 @@ That advertised hostname can then be backed by operator-managed DNS or load-bala
 For example, `az1` can resolve to proxy endpoints in zone `az1`, while `az2` resolves to proxy endpoints in zone `az2`.
 The exact DNS and networking implementation remains outside Kroxylicious.
 
-If the broker rack value is unavailable or unmapped and no `rackIdDefault` is configured, address generation fails.
-This makes misconfiguration visible rather than silently advertising an incomplete or incorrect hostname.
+Using `$(rackId)` requires `rackIdDefault`.
+This gives Kroxylicious a deterministic advertised address label when the upstream rack value is unavailable or unmapped.
 
 ### Protocol-level consistency
 
@@ -123,13 +124,10 @@ The hostname label controls the network path to Kroxylicious.
 The Kafka protocol rack value continues to control Kafka features that depend on rack identity.
 Because Kroxylicious does not rewrite protocol rack values, features such as KIP-392 rack-aware fetching continue to use the upstream Kafka rack values and do not require reverse mapping by the proxy.
 
-If no `rackIdMappings` is configured, Kroxylicious uses the upstream Kafka rack value directly as the advertised address label.
-Operators should only use this mode when their broker rack values are already suitable for their advertised hostname pattern.
-
-If `rackIdMappings` is configured and the upstream rack value is missing or unmapped, Kroxylicious uses `rackIdDefault` if configured.
+If the upstream rack value is missing or unmapped, Kroxylicious uses `rackIdDefault`.
 The default is an advertised address fallback label.
 It should be used for cases where the operator prefers deterministic DNS behavior over failing address generation for unknown rack values.
-This means that, when mappings are configured, an unmapped upstream rack value is not passed directly into the advertised hostname.
+This means that an unmapped upstream rack value is not passed directly into the advertised hostname.
 
 ### DNS validity
 
@@ -169,8 +167,7 @@ Other response types can contain broker endpoints without rack metadata.
 For example, `FindCoordinatorResponse` identifies the coordinator by node ID, host, and port, but does not include broker rack information.
 
 For responses that contain broker endpoints but do not include rack metadata, Kroxylicious should use a rack value previously learned from metadata for the same node ID.
-If no learned rack value is available, Kroxylicious uses `rackIdDefault` if configured.
-If no learned rack value is available and no default is configured, address generation fails.
+If no learned rack value is available, Kroxylicious uses `rackIdDefault`.
 Using `rackIdDefault` can cause an early control-plane response to use the default rack label before metadata has been observed, but it preserves routing correctness because SNI reverse mapping remains based on node ID.
 
 ### Lifecycle
@@ -181,8 +178,8 @@ For other responses that contain broker endpoints, Kroxylicious can only generat
 
 This has implications for SNI endpoint lifecycle.
 Configurations that eagerly create broker endpoints from configured node ID ranges cannot generate rack-aware broker endpoints before upstream metadata has been observed.
-For a SNI configuration using `$(rackId)`, eager endpoint creation can only use `rackIdDefault`.
-If no default is configured, rack-aware endpoints should be created by metadata-driven endpoint reconciliation once upstream metadata has been observed.
+For a SNI configuration using `$(rackId)`, eager endpoint creation uses `rackIdDefault`.
+Once upstream metadata has been observed, rack-aware endpoints should be updated by metadata-driven endpoint reconciliation.
 
 If a broker rack value changes, Kroxylicious should treat that as a change in the generated advertised broker address during normal endpoint reconciliation.
 The new hostname should be generated from the updated metadata, and stale endpoint bindings generated from the previous rack value should be removed according to the existing reconciliation lifecycle.
@@ -244,8 +241,8 @@ The new behavior is opt-in:
 * Strategies that do not use rack metadata continue to generate broker addresses from node ID alone.
 
 There are compatibility considerations for `$(rackId)`.
-If the upstream Kafka cluster does not expose broker rack metadata, a pattern using `$(rackId)` cannot be resolved.
-Operators can configure `rackIdDefault` when they need deterministic fallback behavior for missing or unmapped rack values.
+If the upstream Kafka cluster does not expose broker rack metadata, or exposes a rack value without a configured mapping, `rackIdDefault` is used.
+Because of this, `rackIdDefault` is required when `$(rackId)` is used.
 
 The reverse SNI mapping must continue to extract exactly the node ID from the advertised broker hostname.
 Rack labels must not become part of the node identity.
@@ -280,7 +277,7 @@ Kafka protocol rack identity remains unchanged.
 Inline token defaults such as `$(rackId:az1)` were also rejected because token-level default syntax would imply that other tokens should support the same form.
 Defaults belong to the rack address label configuration rather than the generic address templating language.
 
-### Making rack ID required
+### Making rack-aware addressing mandatory
 
 Making rack metadata mandatory was rejected because many Kafka clusters either do not configure broker rack values or do not need rack-aware DNS names.
 The feature should be opt-in and compatible with existing deployments.

--- a/proposals/120-rack-aware-sni-broker-address-patterns.md
+++ b/proposals/120-rack-aware-sni-broker-address-patterns.md
@@ -1,7 +1,7 @@
 # 120 - Rack-aware SNI broker address patterns
 
-This proposal adds optional rack-aware broker address generation to the SNI node identification strategy.
-It allows an advertised broker address pattern to include broker rack metadata learned from Kafka metadata responses.
+This proposal adds rack-derived broker address generation to the SNI node identification strategy.
+It uses broker rack metadata learned from Kafka metadata responses and configured DNS label mappings to build advertised broker addresses without changing Kafka protocol rack metadata.
 
 ## Current situation
 
@@ -42,11 +42,11 @@ In a multi-zone deployment, the client-facing load balancer, the Kroxylicious po
 For example:
 
 ```text
-client -> network load balancer endpoint in zone-a
-       -> Kroxylicious pod in zone-b
-       -> Kafka broker or partition leader in zone-c
+Client → Network Load Balancer (NLB) endpoint in Zone A
+*(assuming cross-zone load balancing is disabled between the NLB and Kroxylicious pods)*
+→ Kroxylicious pod in Zone A
+→ Kafka broker or partition leader in Zone C
 ```
-
 When traffic crosses zone boundaries between these hops, operators may pay inter-zone data transfer charges and may also see additional latency.
 This is especially relevant for Kafka because produce and fetch traffic can be high-volume.
 If broker-specific advertised hostnames include a rack or zone label, operators can configure DNS, load balancer targets, ingress policy, or deployment topology so that clients prefer a Kroxylicious endpoint in the same zone as the broker rack or failure domain where possible.
@@ -57,8 +57,9 @@ This does not guarantee that all traffic is zone-local; rather, it gives operato
 
 This proposal deliberately treats the value as generic Kafka rack metadata, not as a cloud-provider-specific availability zone.
 Different Kafka deployments may use rack values to represent physical racks, cloud availability zones, failure domains, or provider-specific placement identifiers.
+For example, in a managed Kafka deployment the broker rack value might be a physical availability-zone ID, a subnet-like placement value, or another provider/operator-defined string.
 Kroxylicious should not call cloud-provider APIs to interpret those values.
-Instead, it should use the rack value that Kafka already exposes and let operators optionally map raw rack values to DNS-friendly labels.
+Instead, it should use the rack value that Kafka already exposes.
 
 ## Proposal
 
@@ -66,25 +67,26 @@ Extend the SNI node identification strategy so `advertisedBrokerAddressPattern` 
 
 ```text
 $(rackId)
-$(rackId:<default>)
 ```
 
 When Kroxylicious rewrites a metadata response, it uses the broker rack value from the metadata response for `$(rackId)`.
-When a mapping is configured, the raw rack value is first translated through that mapping before being substituted into the advertised hostname.
+If `rackIdMappings` is configured, Kroxylicious first translates the upstream rack value into an advertised address label.
+If the upstream rack value is missing or does not have a mapping, Kroxylicious uses `rackIdDefault` if configured.
 
 Example configuration:
 
 ```yaml
 sniHostIdentifiesNode:
   bootstrapAddress: "cluster.example.net:9192"
-  advertisedBrokerAddressPattern: "broker-$(nodeId)-$(rackId:az1).example.net:9192"
+  advertisedBrokerAddressPattern: "broker-$(nodeId)-$(rackId).example.net:9192"
+  rackIdDefault: az1
   rackIdMappings:
     euc1-az1: az1
     euc1-az2: az2
     euc1-az3: az3
 ```
 
-If broker `0` has rack value `euc1-az1`, Kroxylicious advertises:
+If broker `0` has upstream rack value `euc1-az1`, Kroxylicious advertises:
 
 ```text
 broker-0-az1.example.net:9192
@@ -94,33 +96,54 @@ That advertised hostname can then be backed by operator-managed DNS or load-bala
 For example, `az1` can resolve to proxy endpoints in zone `az1`, while `az2` resolves to proxy endpoints in zone `az2`.
 The exact DNS and networking implementation remains outside Kroxylicious.
 
-If the broker rack value is unavailable and the token has a default, the default is used:
-
-```text
-$(rackId:az1)
-```
-
-If the broker rack value is unavailable and the token has no default, address generation fails.
+If the broker rack value is unavailable or unmapped and no `rackIdDefault` is configured, address generation fails.
 This makes misconfiguration visible rather than silently advertising an incomplete or incorrect hostname.
 
-### Rack ID mappings
+### Protocol-level consistency
 
-`rackIdMappings` is an optional map on the SNI node identification strategy.
-Keys are raw Kafka rack values.
-Values are replacement labels used in the advertised broker address.
+This proposal does not introduce Kafka rack identity translation.
+It uses Kafka broker rack metadata only as input for advertised broker address generation.
+The value substituted for `$(rackId)` is an address label used by DNS, certificates, or load-balancer policy.
+It is not a replacement for the broker rack identity in the Kafka protocol.
 
-For example:
+When `rackIdMappings` is configured, the mapping applies only to advertised broker addresses.
+Kroxylicious should not rewrite Kafka protocol rack fields in responses such as `MetadataResponse` or `DescribeClusterResponse`.
+It should also not rewrite client request fields that carry rack identity, such as the rack ID used by KIP-392 rack-aware fetching.
+Those protocol fields remain in the upstream cluster's rack namespace.
 
-```yaml
-rackIdMappings:
-  euc1-az1: az1
+For example, if upstream metadata says broker `0` has rack `euc1-az1`, and `rackIdMappings` maps `euc1-az1` to address label `az1`, the client may see:
+
+```text
+advertised hostname: broker-0-az1.example.net
+metadata rack:       euc1-az1
 ```
 
-This lets operators keep stable DNS labels even when raw Kafka rack values differ between environments or providers.
-It also avoids making Kroxylicious aware of cloud-provider-specific naming rules.
+This is intentional.
+The hostname label controls the network path to Kroxylicious.
+The Kafka protocol rack value continues to control Kafka features that depend on rack identity.
+Because Kroxylicious does not rewrite protocol rack values, features such as KIP-392 rack-aware fetching continue to use the upstream Kafka rack values and do not require reverse mapping by the proxy.
 
-If no mapping exists for a non-empty rack value, the raw rack value is used as-is.
-Operators should configure mappings when raw rack values are not suitable for use in DNS hostnames, or when they want stable DNS labels that differ from the values exposed by Kafka.
+If no `rackIdMappings` is configured, Kroxylicious uses the upstream Kafka rack value directly as the advertised address label.
+Operators should only use this mode when their broker rack values are already suitable for their advertised hostname pattern.
+
+If `rackIdMappings` is configured and the upstream rack value is missing or unmapped, Kroxylicious uses `rackIdDefault` if configured.
+The default is an advertised address fallback label.
+It should be used for cases where the operator prefers deterministic DNS behavior over failing address generation for unknown rack values.
+This means that, when mappings are configured, an unmapped upstream rack value is not passed directly into the advertised hostname.
+
+### DNS validity
+
+Kafka broker rack values are arbitrary strings.
+Not every legal Kafka rack value is valid inside a DNS hostname.
+For example, `rack/shelf-3:unit_7` may be a legal broker rack value, but it is not a valid DNS label.
+Provider-specific values such as availability-zone IDs or subnet-derived placement labels may also be unsuitable for the operator's desired DNS naming scheme.
+
+Today the existing node identification strategies perform basic pattern, token, port, and URI-style checks.
+They do not perform full DNS label validation for generated advertised broker hostnames.
+This proposal does not change that validation model.
+If an advertised address fails the existing validation checks, address generation fails.
+Otherwise, Kroxylicious treats hostname suitability as an operator responsibility, as it does for existing advertised broker address patterns.
+Operators should use `rackIdMappings` to translate arbitrary upstream rack values into advertised address labels that are suitable for their DNS, certificate, and load-balancer conventions.
 
 ### Usage model
 
@@ -129,7 +152,8 @@ For example, an operator might:
 
 * configure Kafka broker rack values to represent broker failure domains,
 * configure Kroxylicious pods or services in the same failure domains,
-* advertise broker hostnames containing `$(rackId)` or a mapped rack label,
+* configure rack mappings from upstream provider-specific rack values to stable DNS labels,
+* advertise broker hostnames containing `$(rackId)`,
 * configure DNS or load-balancer policy so each rack label resolves to the appropriate Kroxylicious endpoint.
 
 Kroxylicious remains responsible for producing consistent advertised broker hostnames and reverse-mapping those hostnames back to broker node IDs.
@@ -140,8 +164,29 @@ The surrounding infrastructure remains responsible for resolving and routing tho
 When handling Kafka metadata responses, Kroxylicious already rewrites upstream broker host and port values into client-facing broker addresses.
 This proposal extends that path to pass the broker rack value to the node identification strategy when generating the advertised broker address.
 
-The rack value is only available in responses that carry broker rack metadata.
-Other response types that contain broker endpoints continue to use the existing node-ID-only behavior unless rack metadata is available.
+The rack value is only available in responses that carry broker rack metadata, such as metadata responses.
+Other response types can contain broker endpoints without rack metadata.
+For example, `FindCoordinatorResponse` identifies the coordinator by node ID, host, and port, but does not include broker rack information.
+
+For responses that contain broker endpoints but do not include rack metadata, Kroxylicious should use a rack value previously learned from metadata for the same node ID.
+If no learned rack value is available, Kroxylicious uses `rackIdDefault` if configured.
+If no learned rack value is available and no default is configured, address generation fails.
+Using `rackIdDefault` can cause an early control-plane response to use the default rack label before metadata has been observed, but it preserves routing correctness because SNI reverse mapping remains based on node ID.
+
+### Lifecycle
+
+Rack-aware address generation depends on upstream metadata.
+For metadata responses, the rack value is available in the response being rewritten.
+For other responses that contain broker endpoints, Kroxylicious can only generate a rack-aware address after it has previously learned the broker's rack from metadata.
+
+This has implications for SNI endpoint lifecycle.
+Configurations that eagerly create broker endpoints from configured node ID ranges cannot generate rack-aware broker endpoints before upstream metadata has been observed.
+For a SNI configuration using `$(rackId)`, eager endpoint creation can only use `rackIdDefault`.
+If no default is configured, rack-aware endpoints should be created by metadata-driven endpoint reconciliation once upstream metadata has been observed.
+
+If a broker rack value changes, Kroxylicious should treat that as a change in the generated advertised broker address during normal endpoint reconciliation.
+The new hostname should be generated from the updated metadata, and stale endpoint bindings generated from the previous rack value should be removed according to the existing reconciliation lifecycle.
+Existing client connections can continue using the connection they already established, but a client that tries to open a new connection using a cached stale hostname may need to refresh metadata and retry.
 
 ### Endpoint registration and reverse mapping
 
@@ -162,6 +207,12 @@ broker-$(rackId).$(nodeId).example.net
 
 This proposal is limited to the SNI node identification strategy.
 It does not change the port-based node identification strategy.
+Port mode is excluded because this proposal is about hostname/SNI-based routing.
+In `portIdentifiesNode`, broker identity is primarily represented by the port number, often using a shared DNS name for all brokers.
+For example, broker `0` might be advertised as `cluster.example.net:9193` and broker `1` as `cluster.example.net:9194`.
+Embedding rack labels into broker hostnames does not provide the same routing mechanism in that model.
+This is a scoping choice rather than a fundamental limitation.
+If future work defines a useful rack-aware lifecycle and routing model for port-based listeners, it can be considered separately.
 It does not introduce cloud-provider integrations.
 It does not require users to configure rack-aware patterns.
 
@@ -178,6 +229,7 @@ Not affected:
 * Existing SNI configurations that only use `$(nodeId)` and existing supported tokens.
 * Kubernetes operator APIs, unless a future proposal chooses to surface validation or documentation through Kubernetes-specific schema changes.
 * Filter plugin APIs.
+* Kafka protocol rack fields in responses and requests, including rack IDs used by rack-aware fetching.
 * Cloud-provider KMS providers and other unrelated integrations.
 
 ## Compatibility
@@ -187,13 +239,13 @@ Existing configurations remain valid and keep their existing behavior.
 
 The new behavior is opt-in:
 
-* If `advertisedBrokerAddressPattern` does not contain `$(rackId)` or `$(rackId:<default>)`, rack metadata is ignored.
+* If `advertisedBrokerAddressPattern` does not contain `$(rackId)`, rack metadata is ignored.
 * Existing tokens retain their current meaning.
 * Strategies that do not use rack metadata continue to generate broker addresses from node ID alone.
 
-There are compatibility considerations for `$(rackId)` without a default.
+There are compatibility considerations for `$(rackId)`.
 If the upstream Kafka cluster does not expose broker rack metadata, a pattern using `$(rackId)` cannot be resolved.
-Operators can avoid that by using `$(rackId:<default>)`.
+Operators can configure `rackIdDefault` when they need deterministic fallback behavior for missing or unmapped rack values.
 
 The reverse SNI mapping must continue to extract exactly the node ID from the advertised broker hostname.
 Rack labels must not become part of the node identity.
@@ -217,6 +269,16 @@ If a filter rewrote metadata independently, Kroxylicious could advertise hostnam
 This was rejected because `HostPort` represents only an address.
 Rack metadata is broker topology metadata, not part of a host/port pair.
 Keeping rack metadata separate avoids leaking broker-specific concerns into a generic address type.
+
+### Protocol rack identity mapping
+
+Mapping rack IDs as a full client-facing Kafka rack identity was considered and rejected for this proposal.
+That would require Kroxylicious to rewrite protocol rack fields in responses and reverse-map client-supplied rack IDs in requests such as KIP-392 fetch requests.
+This proposal is intentionally narrower: it uses broker rack metadata only to derive advertised broker address labels for routing through operator-managed DNS or load-balancer policy.
+Kafka protocol rack identity remains unchanged.
+
+Inline token defaults such as `$(rackId:az1)` were also rejected because token-level default syntax would imply that other tokens should support the same form.
+Defaults belong to the rack address label configuration rather than the generic address templating language.
 
 ### Making rack ID required
 

--- a/proposals/120-rack-aware-sni-broker-address-patterns.md
+++ b/proposals/120-rack-aware-sni-broker-address-patterns.md
@@ -1,7 +1,7 @@
 # 120 - Rack-aware SNI broker address patterns
 
 This proposal adds rack-derived broker address generation to the SNI node identification strategy.
-It uses broker rack metadata learned from Kafka metadata responses, a required `rackIdDefault`, and optional `rackIdMappings` to build advertised broker addresses without changing Kafka protocol rack metadata.
+It uses Kafka broker rack metadata as lookup input, a required `defaultRackAddress`, and optional `rackAddressMappings` to build advertised broker addresses without changing Kafka protocol rack metadata.
 
 ## Current situation
 
@@ -67,24 +67,27 @@ Instead, it should use the rack value that Kafka already exposes.
 Extend the SNI node identification strategy so `advertisedBrokerAddressPattern` may use this additional token:
 
 ```text
-$(rackId)
+$(rackAddress)
 ```
 
-When Kroxylicious rewrites a metadata response, it uses the broker rack value from the metadata response for `$(rackId)`.
-If `rackIdMappings` contains the upstream rack value, Kroxylicious translates it into the configured advertised address label.
-If the upstream rack value is missing or does not have a mapping, Kroxylicious uses `rackIdDefault`.
+When Kroxylicious rewrites a metadata response, it uses the broker Kafka `rackId` from that response to resolve `$(rackAddress)`.
+If `rackAddressMappings` contains an entry whose `rackId` matches the upstream Kafka rack ID, Kroxylicious substitutes the corresponding `rackAddress` label.
+If the upstream Kafka rack ID is missing or does not have a mapping, Kroxylicious uses `defaultRackAddress`.
 
 Example configuration:
 
 ```yaml
 sniHostIdentifiesNode:
   bootstrapAddress: "cluster.example.net:9192"
-  advertisedBrokerAddressPattern: "broker-$(nodeId)-$(rackId).example.net:9192"
-  rackIdDefault: az1
-  rackIdMappings:
-    euc1-az1: az1
-    euc1-az2: az2
-    euc1-az3: az3
+  advertisedBrokerAddressPattern: "broker-$(nodeId)-$(rackAddress).example.net:9192"
+  defaultRackAddress: az1
+  rackAddressMappings:
+    - rackId: euc1-az1
+      rackAddress: az1
+    - rackId: euc1-az2
+      rackAddress: az2
+    - rackId: euc1-az3
+      rackAddress: az3
 ```
 
 If broker `0` has upstream rack value `euc1-az1`, Kroxylicious advertises:
@@ -97,22 +100,22 @@ That advertised hostname can then be backed by operator-managed DNS or load-bala
 For example, `az1` can resolve to proxy endpoints in zone `az1`, while `az2` resolves to proxy endpoints in zone `az2`.
 The exact DNS and networking implementation remains outside Kroxylicious.
 
-Using `$(rackId)` requires `rackIdDefault`.
+Using `$(rackAddress)` requires `defaultRackAddress`.
 This gives Kroxylicious a deterministic advertised address label when the upstream rack value is unavailable or unmapped.
 
 ### Protocol-level consistency
 
 This proposal does not introduce Kafka rack identity translation.
 It uses Kafka broker rack metadata only as input for advertised broker address generation.
-The value substituted for `$(rackId)` is an address label used by DNS, certificates, or load-balancer policy.
+The value substituted for `$(rackAddress)` is an address label used by DNS, certificates, or load-balancer policy.
 It is not a replacement for the broker rack identity in the Kafka protocol.
 
-When `rackIdMappings` is configured, the mapping applies only to advertised broker addresses.
+When `rackAddressMappings` is configured, it maps a Kafka `rackId` to an advertised `rackAddress` label and applies only to advertised broker addresses.
 Kroxylicious should not rewrite Kafka protocol rack fields in responses such as `MetadataResponse` or `DescribeClusterResponse`.
 It should also not rewrite client request fields that carry rack identity, such as the rack ID used by KIP-392 rack-aware fetching.
 Those protocol fields remain in the upstream cluster's rack namespace.
 
-For example, if upstream metadata says broker `0` has rack `euc1-az1`, and `rackIdMappings` maps `euc1-az1` to address label `az1`, the client may see:
+For example, if upstream metadata says broker `0` has rack `euc1-az1`, and `rackAddressMappings` maps `euc1-az1` to address label `az1`, the client may see:
 
 ```text
 advertised hostname: broker-0-az1.example.net
@@ -124,7 +127,7 @@ The hostname label controls the network path to Kroxylicious.
 The Kafka protocol rack value continues to control Kafka features that depend on rack identity.
 Because Kroxylicious does not rewrite protocol rack values, features such as KIP-392 rack-aware fetching continue to use the upstream Kafka rack values and do not require reverse mapping by the proxy.
 
-If the upstream rack value is missing or unmapped, Kroxylicious uses `rackIdDefault`.
+If the upstream rack value is missing or unmapped, Kroxylicious uses `defaultRackAddress`.
 The default is an advertised address fallback label.
 It should be used for cases where the operator prefers deterministic DNS behavior over failing address generation for unknown rack values.
 This means that an unmapped upstream rack value is not passed directly into the advertised hostname.
@@ -140,7 +143,7 @@ Today the existing node identification strategies perform basic pattern, token, 
 They do not perform full DNS label validation for generated advertised broker hostnames.
 This proposal does not change that validation model.
 Kroxylicious treats hostname suitability as an operator responsibility, as it does for existing advertised broker address patterns.
-Operators should use `rackIdMappings` to translate arbitrary upstream rack values into advertised address labels that are suitable for their DNS, certificate, and load-balancer conventions.
+Operators should use `rackAddressMappings` to translate arbitrary upstream rack values into advertised address labels that are suitable for their DNS, certificate, and load-balancer conventions.
 
 ### Usage model
 
@@ -149,8 +152,8 @@ For example, an operator might:
 
 * configure Kafka broker rack values to represent broker failure domains,
 * configure Kroxylicious pods or services in the same failure domains,
-* configure rack mappings from upstream provider-specific rack values to stable DNS labels,
-* advertise broker hostnames containing `$(rackId)`,
+* configure rack address mappings from upstream provider-specific rack values to stable DNS labels,
+* advertise broker hostnames containing `$(rackAddress)`,
 * configure DNS or load-balancer policy so each rack label resolves to the appropriate Kroxylicious endpoint.
 
 Kroxylicious remains responsible for producing consistent advertised broker hostnames and reverse-mapping those hostnames back to broker node IDs.
@@ -166,39 +169,53 @@ Other response types can contain broker endpoints without rack metadata.
 For example, `FindCoordinatorResponse` identifies the coordinator by node ID, host, and port, but does not include broker rack information.
 
 For responses that contain broker endpoints but do not include rack metadata, Kroxylicious should use a rack value previously learned from metadata for the same node ID.
-If no learned rack value is available, Kroxylicious uses `rackIdDefault`.
-Using `rackIdDefault` can cause an early control-plane response to use the default rack label before metadata has been observed, but it preserves routing correctness because SNI reverse mapping remains based on node ID.
+If no learned rack value is available, Kroxylicious uses `defaultRackAddress`.
+Using `defaultRackAddress` can cause an early control-plane response to use the default rack label before metadata has been observed, but it preserves routing correctness because SNI reverse mapping remains based on node ID.
+
+The learned broker topology is shared per virtual-cluster gateway, not per client connection.
+It contains the node ID, upstream address, and Kafka rack ID from the last successfully completed endpoint reconciliation.
+This allows a response on one client connection, such as `FindCoordinatorResponse`, to use rack information learned while serving a different client connection.
+
+Metadata responses build the desired topology and are forwarded only after their endpoint reconciliation has completed.
+The active topology is updated only after that reconciliation succeeds, so Kroxylicious does not advertise a new rack-derived hostname before the matching SNI endpoint has been registered.
+If reconciliation fails, the prior active topology remains in use.
 
 ### Lifecycle
 
-Rack-aware address generation depends on upstream metadata.
+Rack-derived address generation depends on upstream metadata.
 For metadata responses, the rack value is available in the response being rewritten.
-For other responses that contain broker endpoints, Kroxylicious can only generate a rack-aware address after it has previously learned the broker's rack from metadata.
+For other responses that contain broker endpoints, Kroxylicious can only generate a rack-derived address after it has previously learned the broker's Kafka rack ID from metadata.
 
 This has implications for SNI endpoint lifecycle.
-Configurations that eagerly create broker endpoints from configured node ID ranges cannot generate rack-aware broker endpoints before upstream metadata has been observed.
-For a SNI configuration using `$(rackId)`, eager endpoint creation uses `rackIdDefault`.
-Once upstream metadata has been observed, rack-aware endpoints should be updated by metadata-driven endpoint reconciliation.
+Before broker rack metadata is available, configurations that eagerly create broker endpoints from configured node ID ranges use `defaultRackAddress`.
+They cannot yet generate a broker-specific address derived from `rackAddressMappings`.
+Once broker metadata has been observed, metadata-driven endpoint reconciliation updates the endpoints with the effective rack-derived advertised addresses.
+
+The active broker topology is replaced only after a successful reconciliation.
+A metadata response supplies the current broker rack IDs directly; other reconciled topology responses reuse rack IDs already learned for the same node ID.
+Consequently, broker removals and node-ID reuse do not retain stale rack IDs after a successful metadata-driven reconciliation.
 
 If a broker rack value changes, Kroxylicious should treat that as a change in the generated advertised broker address during normal endpoint reconciliation.
 The new hostname should be generated from the updated metadata, and reconciliation must detect this as an endpoint change even though the node ID is unchanged.
-This requires rack-aware reconciliation logic; the current node-ID membership reconciliation is not sufficient on its own.
-This may be implemented by tracking the effective generated broker address, or by treating `(nodeId, effectiveRackLabel)` as the endpoint identity for rack-aware SNI bindings.
+This requires rack-derived reconciliation logic; the current node-ID membership reconciliation is not sufficient on its own.
+Reconciliation must compare the effective generated broker address as well as node ID.
+If the node ID is unchanged but the generated hostname differs, Kroxylicious removes the old explicit SNI binding and registers the new one.
+If the Kafka rack ID changes but maps to the same generated hostname, no SNI rebind is necessary, although the shared topology is still updated.
 Existing client connections can continue using the connection they already established, but a client that tries to open a new connection using a cached stale hostname may need to refresh metadata and retry.
 
 ### Endpoint registration and reverse mapping
 
-The same rack-aware address generation must be used when registering broker-specific SNI endpoints.
+The same rack-derived address generation must be used when registering broker-specific SNI endpoints.
 Otherwise Kroxylicious could advertise one hostname in metadata but bind or route a different hostname internally.
 
 The SNI reverse mapping remains node-ID based.
-When the advertised broker address pattern contains a rack token, reverse mapping treats the rack portion of the hostname as a non-node-ID label and continues to extract the node ID from `$(nodeId)`.
+When the advertised broker address pattern contains `$(rackAddress)`, reverse mapping treats the address-label portion of the hostname as a non-node-ID label and continues to extract the node ID from `$(nodeId)`.
 
 For example, both patterns still resolve node ID correctly:
 
 ```text
-broker-$(nodeId)-$(rackId).example.net
-broker-$(rackId).$(nodeId).example.net
+broker-$(nodeId)-$(rackAddress).example.net
+broker-$(rackAddress).$(nodeId).example.net
 ```
 
 ### Scope
@@ -210,7 +227,7 @@ In `portIdentifiesNode`, broker identity is primarily represented by the port nu
 For example, broker `0` might be advertised as `cluster.example.net:9193` and broker `1` as `cluster.example.net:9194`.
 Embedding rack labels into broker hostnames does not provide the same routing mechanism in that model.
 This is a scoping choice rather than a fundamental limitation.
-If future work defines a useful rack-aware lifecycle and routing model for port-based listeners, it can be considered separately.
+If future work defines a useful rack-derived lifecycle and routing model for port-based listeners, it can be considered separately.
 It does not introduce cloud-provider integrations.
 It does not introduce full DNS label validation for generated advertised broker hostnames.
 It does not require existing users to configure rack-aware patterns.
@@ -238,13 +255,13 @@ Existing configurations remain valid and keep their existing behavior.
 
 The new behavior is opt-in:
 
-* If `advertisedBrokerAddressPattern` does not contain `$(rackId)`, rack metadata is ignored.
+* If `advertisedBrokerAddressPattern` does not contain `$(rackAddress)`, Kafka rack metadata is ignored.
 * Existing tokens retain their current meaning.
 * Strategies that do not use rack metadata continue to generate broker addresses from node ID alone.
 
-There are compatibility considerations for `$(rackId)`.
-If the upstream Kafka cluster does not expose broker rack metadata, or exposes a rack value without a configured mapping, `rackIdDefault` is used.
-Because of this, `rackIdDefault` is required when `$(rackId)` is used.
+There are compatibility considerations for `$(rackAddress)`.
+If the upstream Kafka cluster does not expose broker rack metadata, or exposes a rack value without a configured mapping, `defaultRackAddress` is used.
+Because of this, `defaultRackAddress` is required when `$(rackAddress)` is used.
 
 The reverse SNI mapping must continue to extract exactly the node ID from the advertised broker hostname.
 Rack labels must not become part of the node identity.
@@ -276,10 +293,10 @@ That would require Kroxylicious to rewrite protocol rack fields in responses and
 This proposal is intentionally narrower: it uses broker rack metadata only to derive advertised broker address labels for routing through operator-managed DNS or load-balancer policy.
 Kafka protocol rack identity remains unchanged.
 
-Inline token defaults such as `$(rackId:az1)` were also rejected because token-level default syntax would imply that other tokens should support the same form.
+Inline token defaults such as `$(rackAddress:az1)` were also rejected because token-level default syntax would imply that other tokens should support the same form.
 Defaults belong to the rack address label configuration rather than the generic address templating language.
 
-### Making rack-aware addressing mandatory
+### Making rack-derived addressing mandatory
 
-Making rack metadata mandatory was rejected because many Kafka clusters either do not configure broker rack values or do not need rack-aware DNS names.
+Making Kafka rack metadata mandatory was rejected because many Kafka clusters either do not configure broker rack values or do not need rack-derived DNS names.
 The feature should be opt-in and compatible with existing deployments.


### PR DESCRIPTION
This proposal adds rack-aware-derived broker address generation to the SNI node identification strategy.

It allows advertised broker address patterns to include Kafka broker rack metadata using `$(rackId)`. The rack value can be translated through configured `rackIdMappings` into DNS/load-balancer-friendly advertised address labels, with `rackIdDefault` used when the upstream rack value is missing or unmapped.

The motivation is to support topology-aware DNS/load-balancer routing and reduce avoidable cross-zone traffic for high-volume Kafka produce/fetch workloads, without changing Kafka protocol rack metadata or cloud-provider placement semantics.
