### PR TITLE
Add signoff option to commit message in workflow

### DIFF
--- a/.github/workflows/proposal-numbering.yml
+++ b/.github/workflows/proposal-numbering.yml
@@ -153,7 +153,7 @@ jobs:
                   }
 
                   warnings.push(
-                    `git commit -m "Rename proposal to use PR number ${prNumber}"`,
+                    `git commit --signoff -m "Rename proposal to use PR number ${prNumber}"`,
                     'git push',
                     '```',
                     ''


### PR DESCRIPTION
The helpful message about how to fix the proposal file number, when followed, meant that the `git push` would fail CI because the `git commit` lacked a signoff. Signing off on a file rename seems to be something that should always be acceptable. (Requiring signoff is about intellectual property, but I struggle to see an IP-related angle on the name of a file).