### PR TITLE
Add a scratch dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .claude/settings.local.json
+.scratch/


### PR DESCRIPTION
When reviewing changes I've found it useful to assemble batches of comments or notes files. When working with LLMs/agents its much easier to keep those things in tree but there is little to no value in committing them. 

So I'd like to exclude an dir from git that I and anyone else can keep such local musing in.
